### PR TITLE
Allow to use different strategy for color distance determination

### DIFF
--- a/lib/gauguin/color.rb
+++ b/lib/gauguin/color.rb
@@ -25,8 +25,9 @@ module Gauguin
       distance(other_color) <= Gauguin.configuration.color_similarity_threshold
     end
 
-    def distance(other_color)
-      case Gauguin.configuration.color_similarity_method
+    def distance(other_color, color_similarity_method: nil)
+      color_similarity_method ||= Gauguin.configuration.color_similarity_method
+      case color_similarity_method
       when :lab
         distance_lab(other_color)
       when :cie94_graphics


### PR DESCRIPTION
It can be useful if want to use different strategies for different cases (instead of default one).